### PR TITLE
Include python by default in plugin env

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -45,7 +45,9 @@ export function setupAddPlugin() {
           ).join(' ');
         }
         execSync(
-          `${mamba} create --yes --name ${envName} -c conda-forge ${depString}`,
+          // Always install python, we'll need it to pip install the plugin. Plugins
+          // may restrict the version by setting a python requirement in pyproject.toml
+          `${mamba} create --yes --name ${envName} -c conda-forge python ${depString}`,
           { stdio: 'inherit', windowsHide: true }
         );
         logger.info('created mamba env for plugin');


### PR DESCRIPTION
## Description
Without this, if a plugin specifies no `conda_dependencies` in pyproject.toml, plugin installation fails because `pip` isn't available in the environment. It should be assumed that python is installed.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
