### PR TITLE
Add custom pydantic behavior for input field order

### DIFF
--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1560,10 +1560,18 @@ class ModelSpec(BaseModel):
         found_keys = set()
         for group in self.input_field_order:
             for key in group:
-                if key in found_keys:
-                    raise ValueError(
-                        f'Key {key} appears more than once in input_field_order')
-                found_keys.add(key)
+                if isinstance(key, dict):
+                    dict_key = list(key.keys())[0]
+                    for val_key in key[dict_key]:
+                        if key in found_keys:
+                            raise ValueError(
+                                f'Key {key} appears more than once in input_field_order')
+                        found_keys.add(key)
+                else:
+                    if key in found_keys:
+                        raise ValueError(
+                            f'Key {key} appears more than once in input_field_order')
+                    found_keys.add(key)
         for _input in self.inputs:
             if _input.hidden is True:
                 if _input.id in found_keys:

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1563,10 +1563,10 @@ class ModelSpec(BaseModel):
                 if isinstance(key, dict):
                     dict_key = list(key.keys())[0]
                     for val_key in key[dict_key]:
-                        if key in found_keys:
+                        if val_key in found_keys:
                             raise ValueError(
-                                f'Key {key} appears more than once in input_field_order')
-                        found_keys.add(key)
+                                f'Key {val_key} appears more than once in input_field_order')
+                        found_keys.add(val_key)
                 else:
                     if key in found_keys:
                         raise ValueError(

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1516,7 +1516,8 @@ class ModelSpec(BaseModel):
     Example: ``"https://github.com/natcap/invest-demo-plugin/blob/main/README.md"``
     """
 
-    input_field_order: list[list[str]]
+    #input_field_order: list[list[str]]
+    input_field_order: typing.Any
     """A list that specifies the order and grouping of model inputs.
     Inputs will be displayed in the input form from top to bottom in the order
     listed here. Sub-lists represent groups of inputs that will be visually


### PR DESCRIPTION
## Description
Schisto has a unique case where we can have a dictionary in the `input_field_order` which facilitates a unique labeling and styling in the Workbench UI. This PR updates some pydantic rules so a dictionary is allowed as a type.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
